### PR TITLE
Update tft.py

### DIFF
--- a/tft.py
+++ b/tft.py
@@ -50,6 +50,9 @@ def click_to(path, delay=.1):
         click_left(delay)
 # End utility methods
 
+#added game counter in console
+gcounter = int (0)
+
 
 # Start main process
 def queue():
@@ -59,7 +62,11 @@ def queue():
         time.sleep(1)
         click_to("./captures/accept.png")
 
-    print("Loading!")
+    t = time.localtime()    # added for printing time
+    current_time = time.strftime("%H:%M:%S", t)
+    global gcounter         #increasing game count by one
+    gcounter = gcounter + 1 
+    print("Loading at:",current_time, "playing game #",gcounter)
     loading()
 
 


### PR DESCRIPTION
quality of life:
- added game counter (see how many games where played)
- starting time of the game (nice to know when the bot crashes)

#####################################################

#added game counter in console
gcounter = int (0)


# Start main process
def queue():
    if onscreen("./captures/tft logo.png"):
        click_to("./captures/find match ready.png")
    while not onscreen("./captures/loading.png"):
        time.sleep(1)
        click_to("./captures/accept.png")

    t = time.localtime()    # added for printing time
    current_time = time.strftime("%H:%M:%S", t)
    global gcounter         #increasing game count by one
    gcounter = gcounter + 1 
    print("Loading at:",current_time, "playing game #",gcounter)
    loading()

##############################################

Bot started, queuing up!
Loading at: 13:22:02 playing game # 1
Match starting!
In the match now!
Surrendering now!
Queuing up again!
Loading at: 13:56:05 playing game # 2
Match starting!
In the match now!
Surrendering now!
Queuing up again!
Loading at: 14:10:38 playing game # 3
Match starting!
In the match now!
Surrendering now!
Queuing up again!
Loading at: 14:25:32 playing game # 4
Match starting!
In the match now!